### PR TITLE
Add post hook handling for rebar3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: doc compile test compile_test clean_test run_test escriptize deps
 
-REBAR ?= $(shell which rebar || echo ./rebar)
+REBAR ?= $(shell test -e `which rebar` 2>/dev/null && which rebar || echo "./rebar")
 
 TESTDIRS= xtest/testapp-1 xtest/testapp-2
 

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -46,7 +46,13 @@ case os:getenv("TGT") of
 	C2
 end.
 
-REBAR = escript:script_name().
+Script = escript:script_name(),
+REBAR = case filename:basename(Script) of
+            "rebar3" ->
+                "make";
+            _ ->
+                Script
+        end,
 case lists:keyfind(post_hooks, 1, C3) of
     {_, PostHooks} ->
 	PH1 = lists:map(


### PR DESCRIPTION
Add special handling in the rebar.config.script file for
rebar3. Currently rebar3 does not have escriptize support and a project
using rebar3 and an dependent application that relies on the setup
application fails to build when the post hook attempts to execute. If
the escript script file name has a base of rebar3, revert to the default
behavior specificed in the rebar.config file of using make as the
command.

We have a project that's using rebar3 and we would also like to use 
exometer_core for stats, but I immediately hit this issue trying to build
the project once I included exometer_core as a dependency. I'm not 
certain if this is the best way to solve the problem, but it does resolve
the issue for my situation.