### PR TITLE
Fix problem with nested configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean_test:
 eunit: compile
 	${REBAR} eunit
 
-test: compile compile_test
+test: eunit compile_test
 	./setup_gen test xtest/test.conf xtest/releases/1 -pa ${PWD}/ebin
 
 run_test:

--- a/src/setup_gen.erl
+++ b/src/setup_gen.erl
@@ -171,12 +171,13 @@ run(Options) ->
     ?if_verbose(io:fwrite("Options = ~p~n", [Options])),
     Config = read_config(Options),
     ?if_verbose(io:fwrite("Config = ~p~n", [Config])),
-    FullOpts = Options ++ Config,
+    FullOpts = insert_config(Config, Options),
+    ?if_verbose(io:fwrite("FullOpts = ~p~n", [FullOpts])),
     {Name, OutDir, RelDir, RelVsn, GenTarget} = name_and_target(FullOpts),
     ensure_dir(RelDir),
     Roots = roots(FullOpts),
     ?if_verbose(io:fwrite("Roots = ~p~n", [Roots])),
-    check_config(Config),
+    check_config(FullOpts),
     Env = env_vars(FullOpts),
     InstEnv = install_env(Env, FullOpts),
     add_paths(Roots, FullOpts),
@@ -201,6 +202,14 @@ run(Options) ->
                               end, ok),
                    setup_lib:write_eterm("setup_gen.eterm", FullOpts)
            end).
+
+insert_config(Conf, Options) ->
+    lists:flatmap(
+      fun({conf, _} = C) ->
+              [C|Conf];
+         (Other) ->
+              [Other]
+      end, Options).
 
 name_and_target(FullOpts) ->
     Name = option(name, FullOpts),


### PR DESCRIPTION
When using two levels of 'include_lib' expansion, options would
get out of order, which could be problematic for 'set_env' instructions.