### PR TITLE
Add supervisor, app module. Add 'start_setup' option (default: true)

### DIFF
--- a/src/setup_app.erl
+++ b/src/setup_app.erl
@@ -1,6 +1,6 @@
-%% -*- erlang -*-
-%%==============================================================================
-%% Copyright 2014 Ulf Wiger
+%% -*- mode: erlang; indent-tabs-mode: nil; -*-
+%%=============================================================================
+%% Copyright 2014-2016 Ulf Wiger
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -13,17 +13,20 @@
 %% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
-%%==============================================================================
-{application, setup,
- [
-  {description, "Generic setup application for Erlang-based systems"},
-  {vsn, git},
-  {registered, []},
-  {applications, [
-                  kernel,
-                  stdlib
-                 ]},
-  {mod, { setup_app, []}},
-  {start_phases, [{run_setup, []}]},
-  {env, []}
- ]}.
+%%=============================================================================
+-module(setup_app).
+-behaviour(application).
+
+-export([start/2,
+         start_phase/3,
+         stop/1]).
+
+start(_Type, _Args) ->
+    setup_sup:start_link().
+
+start_phase(run_setup, _Type, []) ->
+    _ = setup_srv:run_setup(),
+    ok.
+
+stop(_) ->
+    ok.

--- a/src/setup_gen.erl
+++ b/src/setup_gen.erl
@@ -126,6 +126,10 @@ help() ->
 %%        which, if a `{nodes, Ns}' option is given, also configures Erlang
 %%        to wait for all given nodes, and then start the `setup' application
 %%        on the first node.
+%% * `{start_setup, true|false}' - Tells whether setup should be started
+%%        automatically. The default is `true' (as it should be). The best way
+%%        to include setup, but not start it, would be to add `{setup, load}' to
+%%        the `apps' list.
 %% * `{verbose, true|false}' - (Default: `false') Turns on verbose printouts.
 %%
 %% == Application entries ==
@@ -281,6 +285,7 @@ options(["-conf"         , F|T]) -> [{conf, F}|options(T)];
 options(["-install"])            -> [{install, true}];
 options(["-install" | ["-" ++ _|_] = T]) -> [{install, true}|options(T)];
 options(["-install"      , D|T]) -> [{install, mk_bool(D)}|options(T)];
+options(["-start_setup"  , D|T]) -> [{start_setup, mk_bool(D)}|options(T)];
 options(["-sys"          , D|T]) -> [{sys, D}|options(T)];
 options(["-vsn"          , D|T]) -> [{vsn, D}|options(T)];
 options(["-pa"           , D|T]) -> [{pa, D}|options(T)];
@@ -584,7 +589,11 @@ apps(Options, Env) ->
                 end, sort_apps(Options, Apps1)),
     ?if_verbose(io:fwrite("AppVsns = ~p~n", [AppVsns])),
     %% setup_is_load_only(replace_versions(AppVsns, Apps1)).
-    setup_is_load_only(AppVsns).
+    case proplists:get_value(start_setup, Options, true) of
+        true -> AppVsns;
+        false ->
+            setup_is_load_only(AppVsns)
+    end.
 
 add_remove_apps(Options, _Env) ->
     lists:foldl(

--- a/src/setup_srv.erl
+++ b/src/setup_srv.erl
@@ -1,0 +1,49 @@
+%% -*- mode: erlang; indent-tabs-mode: nil; -*-
+%%=============================================================================
+%% Copyright 2014-2016 Ulf Wiger
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%=============================================================================
+-module(setup_srv).
+-behaviour(gen_server).
+
+-export([start_link/0]).
+-export([run_setup/0]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+run_setup() ->
+    gen_server:call(?MODULE, run_setup).
+
+init(_) ->
+    {ok, []}.
+
+handle_call(run_setup, _From, S) ->
+    {reply, setup:run_setup(), S};
+handle_call(_, _, S) ->
+    {reply, {error, badarg}, S}.
+
+handle_cast(_, S) -> {noreply, S}.
+handle_info(_, S) -> {noreply, S}.
+terminate(_  , _) -> ok.
+
+code_change(_FromVsn, S, _Extra) ->
+    {ok, S}.

--- a/src/setup_sup.erl
+++ b/src/setup_sup.erl
@@ -1,0 +1,28 @@
+%% -*- mode: erlang; indent-tabs-mode: nil; -*-
+%%=============================================================================
+%% Copyright 2014-2016 Ulf Wiger
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%=============================================================================
+-module(setup_sup).
+-behaviour(supervisor).
+
+-export([start_link/0]).
+-export([init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init(_) ->
+    {ok, {{one_for_one, 3, 10}, [{setup_srv, {setup_srv, start_link, []},
+                                  permanent, 2000, worker, [setup_srv]}]}}.


### PR DESCRIPTION
The 'start_setup' option was added to address the weird behavior that
setup_gen always sets setup to load-only in the .rel file. This can
now be achieved by giving -start_setup false, but the appropriate
way would be to give {setup,load} in the 'apps' list.