### PR TITLE
replace post_hooks when rebar3

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -47,21 +47,10 @@ case os:getenv("TGT") of
 end.
 
 Script = escript:script_name(),
-REBAR = case filename:basename(Script) of
-            "rebar3" ->
-                "make";
-            _ ->
-                Script
-        end,
-case lists:keyfind(post_hooks, 1, C3) of
-    {_, PostHooks} ->
-	PH1 = lists:map(
-		fun({compile, "make escriptize"}) ->
-			{compile, REBAR ++ " escriptize"};
-		   (X) -> X
-		end, PostHooks),
-	lists:keyreplace(
-	  post_hooks, 1, C3, {post_hooks, PH1});
-    false ->
+case filename:basename(Script) of
+    "rebar3" ->
+	lists:keydelete(post_hooks, 1, C3)
+	    ++ [{provider_hooks, [{post, [{compile, escriptize}]}]}];
+    _ ->
 	C3
 end.


### PR DESCRIPTION
Ref. issue #24 - replace post_hooks escriptize hook with a provider_hooks entry when running rebar3.