### PR TITLE
Enable building with rebar3

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,6 +12,7 @@
                    "http://github.com/uwiger/setup"}}]}
    ]}
  ]}.
+{escript_main_app, setup}.
 {escript_name, setup_gen}.
 {post_hooks, [{compile, "make escriptize"}]}.
 


### PR DESCRIPTION
Hi Ulf,

Need this extra directive to enable this application to be used as a dependency in a rebar3 project. The `escript_main_app` is mandatory in rebar3.