### PR TITLE
Add default make binary to use

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,7 +14,7 @@
  ]}.
 {escript_main_app, setup}.
 {escript_name, setup_gen}.
-{post_hooks, [{compile, "${MAKE} escriptize"}]}.
+{post_hooks, [{compile, "${MAKE:-make} escriptize"}]}.
 
 %% This line is to ensure that any erl_first_files setting from
 %% 'above' isn't accidentally inherited, since there seems to be


### PR DESCRIPTION
This fixes an issue where the `MAKE` variable wouldn't be set when `setup` was being compiled directly by `rebar` instead of going through the `Makefile`.