### PR TITLE
fix crash in roots_of()

### DIFF
--- a/src/setup.erl
+++ b/src/setup.erl
@@ -729,7 +729,7 @@ roots_of(Path) ->
     All = lists:foldr(
             fun(D, Acc) ->
                     case lists:reverse(filename:split(D)) of
-                        ["ebin",_|T] ->
+                        ["ebin",_| [_|_] = T] ->
                             [filename:join(lists:reverse(T)) | Acc];
                         _ ->
                             Acc


### PR DESCRIPTION
Example of crash:
```erlang
(epoch_dev1@localhost)1> setup:find_app(sasl).
** exception error: no function clause matching filename:join([]) (filename.erl, line 399)
     in function  setup:'-roots_of/1-fun-0-'/2 (/Users/uwiger/aeternity/tmp3/epoch/_build/default/lib/setup/src/setup.erl, line 733)
     in call from setup:roots_of/1 (/Users/uwiger/aeternity/tmp3/epoch/_build/default/lib/setup/src/setup.erl, line 729)
     in call from setup:find_app/2 (/Users/uwiger/aeternity/tmp3/epoch/_build/default/lib/setup/src/setup.erl, line 701)
```

This can happen e.g. when an entry like `"patches/ebin"` is in the path, leading to a call to `filename:join([])`.