### PR TITLE
update version list for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,8 @@ sudo: false
 language: erlang
 script: "make ci"
 otp_release:
-  - 22.0.1
-  - 21.0.2
+  - 22.0.7
+  - 21.3
   - 20.3
   - 19.3
-  - 19.1
   - 18.3
-  - 18.2.1
-  - 18.2
-  - 18.1
-  - 18.0
-  - 17.5


### PR DESCRIPTION
OTP versions available for Travis can be seen here:
https://docs.travis-ci.com/user/languages/erlang/