### PR TITLE
Use error_report to avoid line breaks on run_setup crash

### DIFF
--- a/src/setup.erl
+++ b/src/setup.erl
@@ -954,9 +954,9 @@ run_setup() ->
     try run_setup_()
     catch
         ?EXCEPTION(error, Error, Stacktrace) ->
-            error_logger:error_msg("Caught exception:~n"
-                                   "~p~n"
-                                   "~p~n", [Error, ?GET_STACK(Stacktrace)]),
+            error_logger:error_report([{run_setup_failed, Error},
+                                       {abort_on_error, AbortOnError},
+                                       {stacktrace, ?GET_STACK(Stacktrace)}]),
             if AbortOnError ->
                     erlang:error(Error);
                true ->


### PR DESCRIPTION
See aeternity/aeternity#4092

Using `error_logger:error_report/1` instead of explicit formatting plays well with `lager`.