### PR TITLE
setup_file handles escript archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,7 @@ in [`setup`](http://github.com/uwiger/setup/blob/master/doc/setup.md).
 
 <table width="100%" border="0" summary="list of modules">
 <tr><td><a href="http://github.com/uwiger/setup/blob/master/doc/setup.md" class="module">setup</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/setup/blob/master/doc/setup_app.md" class="module">setup_app</a></td></tr>
+<tr><td><a href="http://github.com/uwiger/setup/blob/master/doc/setup_file.md" class="module">setup_file</a></td></tr>
 <tr><td><a href="http://github.com/uwiger/setup/blob/master/doc/setup_gen.md" class="module">setup_gen</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/setup/blob/master/doc/setup_lib.md" class="module">setup_lib</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/setup/blob/master/doc/setup_srv.md" class="module">setup_srv</a></td></tr>
-<tr><td><a href="http://github.com/uwiger/setup/blob/master/doc/setup_sup.md" class="module">setup_sup</a></td></tr></table>
+<tr><td><a href="http://github.com/uwiger/setup/blob/master/doc/setup_lib.md" class="module">setup_lib</a></td></tr></table>
+

--- a/doc/README.md
+++ b/doc/README.md
@@ -6,7 +6,7 @@ __Authors:__ Ulf Wiger ([`ulf@wiger.net`](mailto:ulf@wiger.net)).
 
 Generic setup utility for Erlang-based systems
 
-[![Build Status](https://travis-ci.org/uwiger/setup.svg)](https://travis-ci.org/uwiger/setup)
+[![Build Status](https://github.com/uwiger/setup/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/uwiger/setup/actions/workflows/ci.yml)
 
 
 ## Introduction ##
@@ -117,9 +117,7 @@ in [`setup`](setup.md).
 
 <table width="100%" border="0" summary="list of modules">
 <tr><td><a href="setup.md" class="module">setup</a></td></tr>
-<tr><td><a href="setup_app.md" class="module">setup_app</a></td></tr>
+<tr><td><a href="setup_file.md" class="module">setup_file</a></td></tr>
 <tr><td><a href="setup_gen.md" class="module">setup_gen</a></td></tr>
-<tr><td><a href="setup_lib.md" class="module">setup_lib</a></td></tr>
-<tr><td><a href="setup_srv.md" class="module">setup_srv</a></td></tr>
-<tr><td><a href="setup_sup.md" class="module">setup_sup</a></td></tr></table>
+<tr><td><a href="setup_lib.md" class="module">setup_lib</a></td></tr></table>
 

--- a/doc/edoc-info
+++ b/doc/edoc-info
@@ -1,3 +1,3 @@
 %% encoding: UTF-8
 {application,setup}.
-{modules,[setup,setup_app,setup_gen,setup_lib,setup_srv,setup_sup]}.
+{modules,[setup,setup_file,setup_gen,setup_lib]}.

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -144,13 +144,26 @@ cause a (rather inelegant) boot sequence failure.<a name="index"></a>
 ## Function Index ##
 
 
-<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#data_dir-0">data_dir/0</a></td><td>Returns the configured data dir, or a best guess (<code>home()/data.Node</code>).</td></tr><tr><td valign="top"><a href="#expand_value-2">expand_value/2</a></td><td>Expand <code>Value</code> using global variables and the variables of <code>App</code></td></tr><tr><td valign="top"><a href="#find_app-1">find_app/1</a></td><td>Equivalent to <a href="#find_app-2"><tt>find_app(A, lib_dirs())</tt></a>.</td></tr><tr><td valign="top"><a href="#find_app-2">find_app/2</a></td><td>Locates application <code>A</code> along LibDirs (see <a href="#lib_dirs-0"><code>lib_dirs/0</code></a> and
-<a href="#lib_dirs-1"><code>lib_dirs/1</code></a>) or under the OTP root, returning all found candidates.</td></tr><tr><td valign="top"><a href="#find_env_vars-1">find_env_vars/1</a></td><td>Searches all loaded apps for instances of the <code>Env</code> environment variable.</td></tr><tr><td valign="top"><a href="#find_hooks-0">find_hooks/0</a></td><td>Finds all custom setup hooks in all applications.</td></tr><tr><td valign="top"><a href="#find_hooks-1">find_hooks/1</a></td><td>Find all setup hooks for <code>Mode</code> in all applications.</td></tr><tr><td valign="top"><a href="#find_hooks-2">find_hooks/2</a></td><td>Find all setup hooks for <code>Mode</code> in <code>Applications</code>.</td></tr><tr><td valign="top"><a href="#get_all_env-1">get_all_env/1</a></td><td>Like <code>application:get_all_env/1</code>, but with variable expansion.</td></tr><tr><td valign="top"><a href="#get_env-2">get_env/2</a></td><td></td></tr><tr><td valign="top"><a href="#get_env-3">get_env/3</a></td><td></td></tr><tr><td valign="top"><a href="#home-0">home/0</a></td><td>Returns the configured <code>home</code> directory, or a best guess (<code>$CWD</code>).</td></tr><tr><td valign="top"><a href="#lib_dirs-0">lib_dirs/0</a></td><td>Equivalent to <a href="#union-2"><tt>union(lib_dirs("ERL_SETUP_LIBS"), lib_dirs("ERL_LIBS"))</tt></a>.</td></tr><tr><td valign="top"><a href="#lib_dirs-1">lib_dirs/1</a></td><td>Returns an expanded list of application directories under a lib path.</td></tr><tr><td valign="top"><a href="#log_dir-0">log_dir/0</a></td><td>Returns the configured log dir, or a best guess (<code>home()/log.Node</code>).</td></tr><tr><td valign="top"><a href="#mode-0">mode/0</a></td><td>Returns the current "setup mode".</td></tr><tr><td valign="top"><a href="#ok-1">ok/1</a></td><td></td></tr><tr><td valign="top"><a href="#patch_app-1">patch_app/1</a></td><td>Adds an application's "development" path to a target system.</td></tr><tr><td valign="top"><a href="#pick_vsn-3">pick_vsn/3</a></td><td>Picks the specified version out of a list returned by <a href="#find_app-1"><code>find_app/1</code></a></td></tr><tr><td valign="top"><a href="#read_config_script-3">read_config_script/3</a></td><td></td></tr><tr><td valign="top"><a href="#read_config_script-4">read_config_script/4</a></td><td></td></tr><tr><td valign="top"><a href="#reload_app-1">reload_app/1</a></td><td>Equivalent to <a href="#reload_app-2"><tt>reload_app(AppName, latest)</tt></a>.</td></tr><tr><td valign="top"><a href="#reload_app-2">reload_app/2</a></td><td>Equivalent to <a href="#reload_app-3"><tt>reload_app(AppName, latest, lib_dirs())</tt></a>.</td></tr><tr><td valign="top"><a href="#reload_app-3">reload_app/3</a></td><td>Loads or upgrades an application to the specified version.</td></tr><tr><td valign="top"><a href="#run_hooks-0">run_hooks/0</a></td><td>Execute all setup hooks for current mode in order.</td></tr><tr><td valign="top"><a href="#run_hooks-1">run_hooks/1</a></td><td>Execute setup hooks for current mode in <code>Applications</code> in order.</td></tr><tr><td valign="top"><a href="#run_hooks-2">run_hooks/2</a></td><td>Execute setup hooks for <code>Mode</code> in <code>Applications</code> in order.</td></tr><tr><td valign="top"><a href="#verify_dir-1">verify_dir/1</a></td><td>Ensures that the directory Dir exists and is writable.</td></tr><tr><td valign="top"><a href="#verify_directories-0">verify_directories/0</a></td><td>Ensures that essential directories exist and are writable.</td></tr></table>
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#applications-0">applications/0</a></td><td>Find all applications - either from the boot script or all loaded apps.</td></tr><tr><td valign="top"><a href="#data_dir-0">data_dir/0</a></td><td>Returns the configured data dir, or a best guess (<code>home()/data.Node</code>).</td></tr><tr><td valign="top"><a href="#expand_value-2">expand_value/2</a></td><td>Expand <code>Value</code> using global variables and the variables of <code>App</code></td></tr><tr><td valign="top"><a href="#expand_value-3">expand_value/3</a></td><td>Expand <code>Value</code> using global variables and the variables of <code>App</code></td></tr><tr><td valign="top"><a href="#find_app-1">find_app/1</a></td><td>Equivalent to <a href="#find_app-2"><tt>find_app(A, lib_dirs())</tt></a>.</td></tr><tr><td valign="top"><a href="#find_app-2">find_app/2</a></td><td>Locates application <code>A</code> along LibDirs (see <a docgen-rel="seemfa" docgen-href="#lib_dirs/0" href="#lib_dirs-0"><code>lib_dirs/0</code></a> and
+<a docgen-rel="seemfa" docgen-href="#lib_dirs/1" href="#lib_dirs-1"><code>lib_dirs/1</code></a>) or under the OTP root, returning all found candidates.</td></tr><tr><td valign="top"><a href="#find_env_vars-1">find_env_vars/1</a></td><td>Searches all loaded apps for instances of the <code>Env</code> environment variable.</td></tr><tr><td valign="top"><a href="#find_hooks-0">find_hooks/0</a></td><td>Finds all custom setup hooks in all applications.</td></tr><tr><td valign="top"><a href="#find_hooks-1">find_hooks/1</a></td><td>Find all setup hooks for <code>Mode</code> in all applications.</td></tr><tr><td valign="top"><a href="#find_hooks-2">find_hooks/2</a></td><td>Find all setup hooks for <code>Mode</code> in <code>Applications</code>.</td></tr><tr><td valign="top"><a href="#get_all_env-1">get_all_env/1</a></td><td>Like <code>application:get_all_env/1</code>, but with variable expansion.</td></tr><tr><td valign="top"><a href="#get_env-2">get_env/2</a></td><td></td></tr><tr><td valign="top"><a href="#get_env-3">get_env/3</a></td><td></td></tr><tr><td valign="top"><a href="#home-0">home/0</a></td><td>Returns the configured <code>home</code> directory, or a best guess (<code>$CWD</code>).</td></tr><tr><td valign="top"><a href="#keep_release-1">keep_release/1</a></td><td>Generates a release based on what's running in the current node.</td></tr><tr><td valign="top"><a href="#lib_dirs-0">lib_dirs/0</a></td><td>Equivalent to <a href="#union-2"><tt>union(lib_dirs("ERL_SETUP_LIBS"), lib_dirs("ERL_LIBS"))</tt></a>.</td></tr><tr><td valign="top"><a href="#lib_dirs-1">lib_dirs/1</a></td><td>Returns an expanded list of application directories under a lib path.</td></tr><tr><td valign="top"><a href="#lib_dirs_under_path-1">lib_dirs_under_path/1</a></td><td></td></tr><tr><td valign="top"><a href="#log_dir-0">log_dir/0</a></td><td>Returns the configured log dir, or a best guess (<code>home()/log.Node</code>).</td></tr><tr><td valign="top"><a href="#mode-0">mode/0</a></td><td>Returns the current "setup mode".</td></tr><tr><td valign="top"><a href="#ok-1">ok/1</a></td><td></td></tr><tr><td valign="top"><a href="#patch_app-1">patch_app/1</a></td><td>Adds an application's "development" path to a target system.</td></tr><tr><td valign="top"><a href="#patch_app-3">patch_app/3</a></td><td></td></tr><tr><td valign="top"><a href="#pick_vsn-3">pick_vsn/3</a></td><td>Picks the specified version out of a list returned by <a docgen-rel="seemfa" docgen-href="#find_app/1" href="#find_app-1"><code>find_app/1</code></a></td></tr><tr><td valign="top"><a href="#read_config_script-3">read_config_script/3</a></td><td></td></tr><tr><td valign="top"><a href="#read_config_script-4">read_config_script/4</a></td><td></td></tr><tr><td valign="top"><a href="#reload_app-1">reload_app/1</a></td><td>Equivalent to <a href="#reload_app-2"><tt>reload_app(AppName, latest)</tt></a>.</td></tr><tr><td valign="top"><a href="#reload_app-2">reload_app/2</a></td><td>Equivalent to <a href="#reload_app-3"><tt>reload_app(AppName, latest, lib_dirs())</tt></a>.</td></tr><tr><td valign="top"><a href="#reload_app-3">reload_app/3</a></td><td>Loads or upgrades an application to the specified version.</td></tr><tr><td valign="top"><a href="#run_hooks-0">run_hooks/0</a></td><td>Execute all setup hooks for current mode in order.</td></tr><tr><td valign="top"><a href="#run_hooks-1">run_hooks/1</a></td><td>Execute setup hooks for current mode in <code>Applications</code> in order.</td></tr><tr><td valign="top"><a href="#run_hooks-2">run_hooks/2</a></td><td>Execute setup hooks for <code>Mode</code> in <code>Applications</code> in order.</td></tr><tr><td valign="top"><a href="#run_selected_hooks-2">run_selected_hooks/2</a></td><td>Execute specified setup hooks in order.</td></tr><tr><td valign="top"><a href="#verify_dir-1">verify_dir/1</a></td><td>Ensures that the directory Dir exists and is writable.</td></tr><tr><td valign="top"><a href="#verify_directories-0">verify_directories/0</a></td><td>Ensures that essential directories exist and are writable.</td></tr></table>
 
 
 <a name="functions"></a>
 
 ## Function Details ##
+
+<a name="applications-0"></a>
+
+### applications/0 ###
+
+<pre><code>
+applications() -&gt; [atom()]
+</code></pre>
+<br />
+
+Find all applications - either from the boot script or all loaded apps.
+The applications list is sorted in top application order, where included
+applications follow directly after the top application they are included in.
 
 <a name="data_dir-0"></a>
 
@@ -175,7 +188,26 @@ expand_value(App::atom(), Value::any()) -&gt; any()
 Expand `Value` using global variables and the variables of `App`
 
 The variable expansion is performed according to the rules outlined in
-[Variable expansion](#Variable_expansion).
+[Variable expansion](#Variable_expansion). If a loop is detected (a variable ends
+up referencing itself), an exception is raised.
+Use of [`expand_value/3`](#expand_value-3) (also providing the initial key name) is
+recommended; this function is primarily here for backward compatibility
+purposes.
+
+<a name="expand_value-3"></a>
+
+### expand_value/3 ###
+
+<pre><code>
+expand_value(App::atom(), Key::atom(), Value::any()) -&gt; any()
+</code></pre>
+<br />
+
+Expand `Value` using global variables and the variables of `App`
+
+The variable expansion is performed according to the rules outlined in
+[Variable expansion](#Variable_expansion). The `Key` name as second argument is used
+for loop detection, in which case an exception will be raised..
 
 <a name="find_app-1"></a>
 
@@ -316,6 +348,17 @@ home() -&gt; Directory
 
 Returns the configured `home` directory, or a best guess (`$CWD`)
 
+<a name="keep_release-1"></a>
+
+### keep_release/1 ###
+
+<pre><code>
+keep_release(RelVsn) -&gt; ok
+</code></pre>
+<br />
+
+Generates a release based on what's running in the current node.
+
 <a name="lib_dirs-0"></a>
 
 ### lib_dirs/0 ###
@@ -344,6 +387,12 @@ This function expands the (ebin/) directories under e.g. `$ERL_SETUP_LIBS` or
 This can be useful e.g. when keeping a special 'extensions' or 'plugin'
 root that is handled via `setup`, but not treated as part of the normal
 'automatic code loading path'.
+
+<a name="lib_dirs_under_path-1"></a>
+
+### lib_dirs_under_path/1 ###
+
+`lib_dirs_under_path(L) -> any()`
 
 <a name="log_dir-0"></a>
 
@@ -395,6 +444,12 @@ target system.
 
 The function will not add the same path again, if the new path is already
 the 'first' path entry for the application `A`.
+
+<a name="patch_app-3"></a>
+
+### patch_app/3 ###
+
+`patch_app(A, Vsn, LibDirs) -> any()`
 
 <a name="pick_vsn-3"></a>
 
@@ -535,6 +590,22 @@ Execute setup hooks for `Mode` in `Applications` in order
 Note that no assumptions can be made about which process each setup hook
 runs in, nor whether it runs in the same process as the previous hook.
 See [`find_hooks/0`](#find_hooks-0) for details on the order of execution.
+
+<a name="run_selected_hooks-2"></a>
+
+### run_selected_hooks/2 ###
+
+<pre><code>
+run_selected_hooks(Mode, Hooks) -&gt; ok
+</code></pre>
+<br />
+
+Execute specified setup hooks in order
+
+Exceptions are caught and printed. This might/should be improved, but the
+general idea is to complete as much as possible of the setup, and perhaps
+repair afterwards. However, the fact that something went wrong should be
+remembered and reflected at the end.
 
 <a name="verify_dir-1"></a>
 

--- a/doc/setup_file.md
+++ b/doc/setup_file.md
@@ -1,0 +1,110 @@
+
+
+# Module setup_file #
+* [Function Index](#index)
+* [Function Details](#functions)
+
+<a name="index"></a>
+
+## Function Index ##
+
+
+<table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#close-1">close/1</a></td><td></td></tr><tr><td valign="top"><a href="#consult-1">consult/1</a></td><td>Like <a docgen-rel="seemfa" docgen-href="file#consult/1" href="file.md#consult-1"><code>file:consult/1</code></a>, but supports paths into <code>zip</code> and <code>escript</code> archives.</td></tr><tr><td valign="top"><a href="#list_dir-1">list_dir/1</a></td><td>Like <a docgen-rel="seemfa" docgen-href="file#list_dir/1" href="file.md#list_dir-1"><code>file:list_dir/1</code></a>, but supports paths into <code>zip</code> and <code>escript</code> archives.</td></tr><tr><td valign="top"><a href="#open-2">open/2</a></td><td></td></tr><tr><td valign="top"><a href="#read_file-1">read_file/1</a></td><td>Like <a docgen-rel="seemfa" docgen-href="file#read_file/1" href="file.md#read_file-1"><code>file:read_file/1</code></a>, but supports paths into <code>zip</code> and <code>escript</code> archives.</td></tr><tr><td valign="top"><a href="#script-1">script/1</a></td><td>Like <a docgen-rel="seemfa" docgen-href="file#script/1" href="file.md#script-1"><code>file:script/1</code></a>, but supports paths into <code>zip</code> and <code>escript</code> archives.</td></tr><tr><td valign="top"><a href="#script-2">script/2</a></td><td>Like <a docgen-rel="seemfa" docgen-href="file#script/2" href="file.md#script-2"><code>file:script/2</code></a>, but supports paths into <code>zip</code> and <code>escript</code> archives.</td></tr></table>
+
+
+<a name="functions"></a>
+
+## Function Details ##
+
+<a name="close-1"></a>
+
+### close/1 ###
+
+`close(Fd) -> any()`
+
+<a name="consult-1"></a>
+
+### consult/1 ###
+
+<pre><code>
+consult(Filename) -&gt; {ok, Terms} | {error, Reason}
+</code></pre>
+
+<ul class="definitions"><li><code>Filename = <a href="http://www.erlang.org/doc/man/file.html#type-name_all">file:name_all()</a></code></li><li><code>Terms = [term()]</code></li><li><code>Reason = <a href="http://www.erlang.org/doc/man/file.html#type-posix">file:posix()</a> | badarg | terminated | system_limit | {Line::integer(), Mod::module(), Term::term()}</code></li></ul>
+
+Like [`file:consult/1`](file.md#consult-1), but supports paths into `zip` and `escript` archives
+
+This function works like `file:consult/1` on normal paths, but instead of failing
+on paths that lead into archives, it does a fair job of entering the archive and
+producing a result.
+
+<a name="list_dir-1"></a>
+
+### list_dir/1 ###
+
+<pre><code>
+list_dir(Dir) -&gt; {ok, Filenames} | {error, Reason}
+</code></pre>
+
+<ul class="definitions"><li><code>Dir = <a href="http://www.erlang.org/doc/man/file.html#type-name_all">file:name_all()</a></code></li><li><code>Filenames = [<a href="http://www.erlang.org/doc/man/file.html#type-filename">file:filename()</a>]</code></li><li><code>Reason = <a href="http://www.erlang.org/doc/man/file.html#type-posix">file:posix()</a> | badarg | {no_translation, Filename::<a href="http://www.erlang.org/doc/man/unicode.html#type-latin1_binary">unicode:latin1_binary()</a>}</code></li></ul>
+
+Like [`file:list_dir/1`](file.md#list_dir-1), but supports paths into `zip` and `escript` archives
+
+This function works like `file:list_dir/1` on normal paths, but instead of failing
+on paths that lead into archives, it does a fair job of entering the archive and
+producing a result.
+
+<a name="open-2"></a>
+
+### open/2 ###
+
+`open(File, Opts) -> any()`
+
+<a name="read_file-1"></a>
+
+### read_file/1 ###
+
+<pre><code>
+read_file(Filename) -&gt; {ok, Binary} | {error, Reason}
+</code></pre>
+
+<ul class="definitions"><li><code>Filename = <a href="http://www.erlang.org/doc/man/file.html#type-name_all">file:name_all()</a></code></li><li><code>Binary = binary()</code></li><li><code>Reason = <a href="http://www.erlang.org/doc/man/file.html#type-posix">file:posix()</a> | badarg | terminated | system_limit</code></li></ul>
+
+Like [`file:read_file/1`](file.md#read_file-1), but supports paths into `zip` and `escript` archives
+
+This function works like `file:read_file/1` on normal paths, but instead of failing
+on paths that lead into archives, it does a fair job of entering the archive and
+producing a result.
+
+<a name="script-1"></a>
+
+### script/1 ###
+
+<pre><code>
+script(Filename) -&gt; {ok, Value} | {error, Reason}
+</code></pre>
+
+<ul class="definitions"><li><code>Filename = <a href="http://www.erlang.org/doc/man/file.html#type-name_all">file:name_all()</a></code></li><li><code>Value = term()</code></li><li><code>Reason = <a href="http://www.erlang.org/doc/man/file.html#type-posix">file:posix()</a> | badarg | terminated | system_limit | {Line::integer(), Mod::module(), Term::term()}</code></li></ul>
+
+Like [`file:script/1`](file.md#script-1), but supports paths into `zip` and `escript` archives
+
+This function works like `file:script/1` on normal paths, but instead of failing
+on paths that lead into archives, it does a fair job of entering the archive and
+producing a result.
+
+<a name="script-2"></a>
+
+### script/2 ###
+
+<pre><code>
+script(Filename, Bindings) -&gt; {ok, Value} | {error, Reason}
+</code></pre>
+
+<ul class="definitions"><li><code>Filename = <a href="http://www.erlang.org/doc/man/file.html#type-name_all">file:name_all()</a></code></li><li><code>Bindings = <a href="http://www.erlang.org/doc/man/erl_eval.html#type-binding_struct">erl_eval:binding_struct()</a></code></li><li><code>Value = term()</code></li><li><code>Reason = <a href="http://www.erlang.org/doc/man/file.html#type-posix">file:posix()</a> | badarg | terminated | system_limit | {Line::integer(), Mod::module(), Term::term()}</code></li></ul>
+
+Like [`file:script/2`](file.md#script-2), but supports paths into `zip` and `escript` archives
+
+This function works like `file:script/2` on normal paths, but instead of failing
+on paths that lead into archives, it does a fair job of entering the archive and
+producing a result.
+

--- a/rebar.config
+++ b/rebar.config
@@ -3,12 +3,15 @@
 {erl_opts, [debug_info]}.
 {profiles,
  [
-  {deps, [{edown, "0.8.4"}]},
-  {edoc_opts, [{doclet, edown_doclet},
-               {app_default, "http://www.erlang.org/doc/man"},
-               {top_level_readme,
-                {"./README.md",
-                 "http://github.com/uwiger/setup"}}]}
+  {doc, [
+         {deps, [{edown, "0.8.4"}]},
+         {edoc_opts, [{doclet, edown_doclet},
+                      {app_default, "http://www.erlang.org/doc/man"},
+                      {branch, "master"},
+                      {top_level_readme,
+                       {"./README.md",
+                        "http://github.com/uwiger/setup", "master"}}]}
+        ]}
  ]}.
 {escript_main_app, setup}.
 {escript_name, setup_gen}.
@@ -20,6 +23,8 @@
           {compile, escriptize}
          ]}
  ]}.
+
+{dialyzer, [{plt_extra_apps, [sasl]}]}.
 
 {post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)",
                escriptize,

--- a/src/setup_app.erl
+++ b/src/setup_app.erl
@@ -14,6 +14,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%=============================================================================
+%% @private
 -module(setup_app).
 -behaviour(application).
 

--- a/src/setup_file.erl
+++ b/src/setup_file.erl
@@ -8,17 +8,32 @@
          script/1,
          script/2]).
 
+-include_lib("stdlib/include/zip.hrl").
+-include_lib("kernel/include/file.hrl").
+
 -ifdef(TEST).
 -compile([export_all, nowarn_export_all]).
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
+%% @doc Like {@link file:list_dir/1}, but supports paths into `zip' and `escript' archives
+%%
+%% This function works like `file:list_dir/1' on normal paths, but instead of failing
+%% on paths that lead into archives, it does a fair job of entering the archive and
+%% producing a result.
+%% @end
+-spec list_dir(Dir) -> {ok, Filenames} | {error, Reason} when
+      Dir :: file:name_all(),
+      Filenames :: [file:filename()],
+      Reason :: file:posix()
+              | badarg
+              | {no_translation, Filename :: unicode:latin1_binary()}.
 list_dir(Dir) ->
     case file:list_dir(Dir) of
         {error, enotdir} = Err ->
             case contains_zip_file(Dir) of
                 {true, D} ->
-                    prim_loader_list_dir(D);
+                    list_dir_zip(D);
                 false ->
                     Err
             end;
@@ -26,12 +41,22 @@ list_dir(Dir) ->
             Other
     end.
 
+%% @doc Like {@link file:read_file/1}, but supports paths into `zip' and `escript' archives
+%%
+%% This function works like `file:read_file/1' on normal paths, but instead of failing
+%% on paths that lead into archives, it does a fair job of entering the archive and
+%% producing a result.
+%% @end
+-spec read_file(Filename) -> {ok, Binary} | {error, Reason} when
+      Filename :: file:name_all(),
+      Binary   :: binary(),
+      Reason   :: file:posix() | badarg | terminated | system_limit.
 read_file(File) ->
     case file:read_file(File) of
         {error, enotdir} = Err ->
             case contains_zip_file(File) of
                 {true, F} ->
-                    prim_loader_read_file(F);
+                    read_file_zip(F);
                 false ->
                     Err
             end;
@@ -39,6 +64,17 @@ read_file(File) ->
             Other
     end.
 
+%% @doc Like {@link file:consult/1}, but supports paths into `zip' and `escript' archives
+%%
+%% This function works like `file:consult/1' on normal paths, but instead of failing
+%% on paths that lead into archives, it does a fair job of entering the archive and
+%% producing a result.
+%% @end
+-spec consult(Filename) -> {ok, Terms} | {error, Reason} when
+      Filename :: file:name_all(),
+      Terms :: [term()],
+      Reason :: file:posix() | badarg | terminated | system_limit
+              | {Line :: integer(), Mod :: module(), Term :: term()}.
 consult(File) ->
     case file:consult(File) of
         {error, enotdir} = Err ->
@@ -52,9 +88,34 @@ consult(File) ->
             Other
     end.
 
+
+%% @doc Like {@link file:script/1}, but supports paths into `zip' and `escript' archives
+%%
+%% This function works like `file:script/1' on normal paths, but instead of failing
+%% on paths that lead into archives, it does a fair job of entering the archive and
+%% producing a result.
+%% @end
+-spec script(Filename) -> {ok, Value} | {error, Reason} when
+      Filename :: file:name_all(),
+      Value :: term(),
+      Reason :: file:posix() | badarg | terminated | system_limit
+              | {Line :: integer(), Mod :: module(), Term :: term()}.
 script(File) ->
     script(File, []).
 
+
+%% @doc Like {@link file:script/2}, but supports paths into `zip' and `escript' archives
+%%
+%% This function works like `file:script/2' on normal paths, but instead of failing
+%% on paths that lead into archives, it does a fair job of entering the archive and
+%% producing a result.
+%% @end
+-spec script(Filename, Bindings) -> {ok, Value} | {error, Reason} when
+      Filename :: file:name_all(),
+      Bindings :: erl_eval:binding_struct(),
+      Value :: term(),
+      Reason :: file:posix() | badarg | terminated | system_limit
+              | {Line :: integer(), Mod :: module(), Term :: term()}.
 script(File, Bindings) ->
     case file:script(File, Bindings) of
         {error, enotdir} = Err ->
@@ -71,20 +132,58 @@ script(File, Bindings) ->
 contains_zip_file(File) when is_atom(File) ->
     contains_zip_file(atom_to_binary(File, utf8));
 contains_zip_file(File) ->
+    case contains_ez_archive(File) of
+        true -> {true, #{type => ez, file => File}};
+        false ->
+            contains_escript_as_dir(File)
+    end.
+
+contains_ez_archive(File) ->
     case re:run(File, "\\.ez", []) of
-        {match, _} -> {true, File};
+        {match, _} -> true;
         nomatch    -> false
     end.
 
-consult_zip(File) ->
-    case prim_loader_read_file(File) of
+contains_escript_as_dir(F) ->
+    contains_escript_as_dir(fix_path_for_prim_loader(F), []).
+
+contains_escript_as_dir(F, Acc) ->
+    case file:read_link_info(F) of
+        {ok, #file_info{type = regular}} ->
+            case escript:extract(F, [compile_source]) of
+                {ok, [{shebang, _}|Rest]} ->
+                    case lists:keyfind(archive, 1, Rest) of
+                        {archive, ArchiveBin} ->
+                            RelF = case Acc of
+                                       [] -> [];
+                                       _  -> filename:join(Acc)
+                                   end,
+                            {true, #{ type => escript,
+                                      archive_file => F,
+                                      archive_bin => ArchiveBin,
+                                      rel_filename => RelF }};
+                        false ->
+                            false
+                    end;
+                _ ->
+                    false
+            end;
+        {error, enotdir} ->
+            contains_escript_as_dir(filename:dirname(F), [filename:basename(F)|Acc]);
+        _ ->
+            false
+    end.
+
+consult_zip(#{} = ZI) ->
+    case read_file_zip(ZI) of
         {ok, Bin} ->
             {ok, Fd} = open_bin(Bin, [read]),
-            R = consult_stream(Fd),
-            _ = close(Fd),
-            R;
-        {error, _} = ReadError ->
-            ReadError
+            try consult_stream(Fd)
+            after
+                _ = close(Fd)
+            end;
+        {error, _} = Error ->
+            Error
     end.
 
 open(File, Opts) ->
@@ -100,7 +199,7 @@ open(File, Opts) ->
             Other
     end.
 
-open_zip(File, Opts) ->
+open_zip(#{type := ez, file := File}, Opts) ->
     case check_opts(Opts) of
         ok ->
             case prim_loader_read_file(File) of
@@ -132,8 +231,6 @@ check_opts([_|Opts]) ->
 check_opts([]) ->
     ok.
 
-
-
 close(Fd) ->
     file:close(Fd).
 
@@ -151,13 +248,14 @@ consult_stream(Fd, Line, Acc) ->
             {ok,lists:reverse(Acc)}
     end.
 
-eval_zip(File, Bs) ->
-    case prim_loader_read_file(File) of
+eval_zip(#{} = ZI, Bs) ->
+    case read_file_zip(ZI) of
         {ok, Bin} ->
             {ok, Fd} = open_bin(Bin, [read]),
-            R = eval_stream(Fd, return, Bs),
-            _ = file:close(Fd),
-            R;
+            try eval_stream(Fd, return, Bs)
+            after
+                _ = file:close(Fd)
+            end;
         Error ->
             Error
     end.
@@ -193,6 +291,36 @@ eval_stream2({eof,EndLine}, _Fd, H, Last, E, _Bs) ->
     end.
 %% - - - - 
 
+list_dir_zip(#{type := ez, file := Dir}) ->
+    prim_loader_list_dir(Dir);
+list_dir_zip(#{type := escript, rel_filename := RelF} = ZI) ->
+    Dir = case RelF of
+              "." -> "";
+              []  -> [];
+              _   -> RelF ++ "/"
+          end,
+    with_escript_zip(
+      fun(Handle) ->
+              case zip:zip_list_dir(Handle) of
+                  {ok, Files} ->
+                      Res = lists:foldr(
+                              fun(#zip_file{name = F}, Acc) ->
+                                      case string:prefix(F, Dir) of
+                                          nomatch -> Acc;
+                                          []      -> Acc;
+                                          Rest ->
+                                              [H|_] = string:split(Rest, "/"),
+                                              [H|Acc]
+                                      end;
+                                 (_, Acc) ->
+                                      Acc
+                              end, [], Files),
+                      {ok, ordsets:from_list(Res)};
+                  {error, _} = Error ->
+                      Error
+              end
+      end, ZI).
+
 prim_loader_list_dir(Dir0) ->
     Dir = fix_path_for_prim_loader(Dir0),
     case erl_prim_loader:list_dir(Dir) of
@@ -202,6 +330,31 @@ prim_loader_list_dir(Dir0) ->
         {ok, _} = Ok ->
             Ok
     end.
+
+read_file_zip(#{type := ez, file := File}) ->
+    prim_loader_read_file(File);
+read_file_zip(#{type := escript,
+                rel_filename := RelF} = ZI) ->
+    with_escript_zip(fun(Handle) ->
+                             case zip:zip_get(RelF, Handle) of
+                                 {ok, {_, Binary}} ->
+                                     {ok, Binary};
+                                 {error, _} = Error ->
+                                     Error
+                             end
+                     end, ZI).
+
+with_escript_zip(F, #{type := escript, archive_bin := ArchiveB}) ->
+    case zip:zip_open(ArchiveB, [memory]) of
+        {ok, Handle} ->
+            try F(Handle)
+            after
+                zip:zip_close(Handle)
+            end;
+        {error,_} = OpenError ->
+            OpenError
+    end.
+
 
 prim_loader_read_file(File0) ->
     File = fix_filename_for_prim_loader(File0),
@@ -239,7 +392,29 @@ setup_file_test_() ->
                fun() -> t_consult(Zip) end,
                fun() -> t_script(Zip) end,
                fun() -> t_read_file(Zip) end,
-               fun() -> t_list_dir(Zip) end
+               fun() -> t_read_file1(Zip) end,
+               fun() -> t_list_dir(Zip) end,
+               fun() -> t_list_dir1(Zip) end
+              ]
+      end]}.
+
+setup_escript_file_test_() ->
+    {foreach,
+     fun() ->
+             create_escript()
+     end,
+     fun(Zip) ->
+             file:delete(Zip)
+     end,
+     [
+      fun(Zip) ->
+              [
+               fun() -> t_consult(Zip) end,
+               fun() -> t_script(Zip) end,
+               fun() -> t_read_file(Zip) end,
+               fun() -> t_read_file1(Zip) end,
+               fun() -> t_list_dir(Zip) end,
+               fun() -> t_list_dir1(Zip) end
               ]
       end]}.
 
@@ -248,10 +423,25 @@ create_zip() ->
     {ok, Cwd} = file:get_cwd(),
     {ok, Bin1} = file:read_file("rebar.config"),
     {ok, Bin2} = file:read_file("rebar.config.script"),
+    {ok, Bin3} = file:read_file("src/setup.app.src"),
     {ok, ZipF} = zip:create(Z, [{"rebar.config", Bin1},
-                                {"rebar.config.script", Bin2}],
+                                {"rebar.config.script", Bin2},
+                                {"src/setup.app.src", Bin3}],
                             [{cwd, Cwd}]),
     ZipF.
+
+create_escript() ->
+    F = "demo.escript",
+    Source = ("%% Demo\nmain(_Args) ->\n"
+              "    io:format(\"~p\",[erlang:system_info(schedulers)]).\n"),
+    {ok, Bin} = escript:create(binary, [shebang, comment, {emu_args, "+S3"},
+                                        {source, list_to_binary(Source)},
+                                        {archive, ["rebar.config",
+                                                   "rebar.config.script",
+                                                   "src/setup.app.src"], []}]),
+    ok = file:write_file(F, Bin),
+    F.
+
 
 t_consult(Zip) ->
     F = "rebar.config",
@@ -279,13 +469,33 @@ t_read_file(Zip) ->
     {ok, Bin} = setup_file:read_file(list_to_atom(ZipF)),
     ok.
 
+t_read_file1(Zip) ->
+    F = "src/setup.app.src",
+    ZipF = filename:join(Zip, F),
+    {ok, Bin} = file:read_file(F),
+    {ok, Bin} = setup_file:read_file(F),
+    {ok, Bin} = setup_file:read_file(ZipF),
+    {ok, Bin} = setup_file:read_file(list_to_binary(ZipF)),
+    {ok, Bin} = setup_file:read_file(list_to_atom(ZipF)),
+    ok.
+
 t_list_dir(Zip) ->
     {ok, Fs} = file:list_dir("."),
     {ok, Fs} = setup_file:list_dir("."),
     {ok, Fs1} = setup_file:list_dir(Zip),
     {ok, Fs1} = setup_file:list_dir(Zip ++ "/"),
     [] = Fs1 -- Fs,
-    ["rebar.config", "rebar.config.script"] = lists:sort(Fs1),
+    ["rebar.config", "rebar.config.script", "src"] = lists:sort(Fs1),
+    ok.
+
+t_list_dir1(Zip) ->
+    {ok, Fs} = file:list_dir("src"),
+    {ok, Fs} = setup_file:list_dir("src"),
+    ZipDir = filename:join(Zip, "src"),
+    {ok, Fs1} = setup_file:list_dir(ZipDir),
+    {ok, Fs1} = setup_file:list_dir(ZipDir ++ "/"),
+    [] =  Fs1 -- Fs,
+    ["setup.app.src"] = Fs1,
     ok.
 
 -endif.

--- a/src/setup_file_io_server.erl
+++ b/src/setup_file_io_server.erl
@@ -17,6 +17,7 @@
 %%
 %% %CopyrightEnd%
 %%
+%% @private
 -module(setup_file_io_server).
 
 %% A simple file server for io to one file instance per server instance.

--- a/src/setup_srv.erl
+++ b/src/setup_srv.erl
@@ -14,6 +14,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%=============================================================================
+%% @private
 -module(setup_srv).
 -behaviour(gen_server).
 

--- a/src/setup_sup.erl
+++ b/src/setup_sup.erl
@@ -14,6 +14,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%=============================================================================
+%% @private
 -module(setup_sup).
 -behaviour(supervisor).
 


### PR DESCRIPTION
The functions in `setup_file` (`read_file/1`, `list_dir/1`, `consult/1`, `script/[1,2]`) now detect both `zip` and `escript` archives.

This can be handy, for example, when accessing `priv/` files from within an escript.
Since the functions work just like the originals on normal paths, the caller doesn't need to know if it's running inside an escript or not.

Adding `priv/` files to an escript can be done e.g. using the (undocumented) `rebar3` option [`escript_incl_priv` option](https://github.com/erlang/rebar3/blob/main/apps/rebar/src/rebar_prv_escriptize.erl#L211-L224).