### PR TITLE
Cleaner node shutdown on start phase errors

### DIFF
--- a/src/setup_app.erl
+++ b/src/setup_app.erl
@@ -28,7 +28,12 @@ start(_Type, _Args) ->
 start_phase(run_setup, _Type, []) ->
     case application:get_env(setup, auto_run_phases, true) of
         true ->
-            _ = setup_srv:run_setup();
+            case setup_srv:run_setup() of
+                ok ->
+                    maybe_stop();
+                {error, _} ->
+                    stop_node_(0)
+            end;
         false ->
             ignore
     end,
@@ -36,3 +41,24 @@ start_phase(run_setup, _Type, []) ->
 
 stop(_) ->
     ok.
+
+maybe_stop() ->
+    Mode = setup:mode(),
+    case setup:get_env(setup, stop_when_done, false) of
+        true when Mode =/= normal ->
+            stop_node();
+        _ ->
+            ok
+    end.
+
+stop_node() ->
+    spawn_link(fun stop_node_/0).
+
+stop_node_() ->
+    StopDelay = setup:get_env(setup, stop_delay, 5000),
+    stop_node_(StopDelay).
+
+stop_node_(Delay) ->
+    error_logger:info_msg("Setup stopping...(Delay=~p)~n", [Delay]),
+    timer:sleep(Delay),
+    rpc:eval_everywhere(init,stop,[0]).

--- a/src/setup_srv.erl
+++ b/src/setup_srv.erl
@@ -33,21 +33,22 @@ start_link() ->
 
 run_setup() ->
     Timeout = setup:get_env(setup, run_timeout, infinity),
-    gen_server:call(?MODULE, run_setup, Timeout).
+    try gen_server:call(?MODULE, run_setup, Timeout)
+    catch
+        exit:timeout ->
+            {error, timeout}
+    end.
 
 init(_) ->
     {ok, []}.
 
 handle_call(run_setup, _From, S) ->
-    Mode = setup:mode(),
-    setup:run_setup(),
-    case setup:get_env(setup, stop_when_done, false) of
-        true when Mode =/= normal ->
-            spawn_link(fun stop_node/0);
-        _ ->
-            ok
-    end,
-    {reply, ok, S};
+    Res = try setup:run_setup(), ok
+          catch
+              error:_ ->
+                  {error, aborted}
+          end,
+    {reply, Res, S};
 handle_call(_, _, S) ->
     {reply, {error, badarg}, S}.
 
@@ -58,8 +59,3 @@ terminate(_  , _) -> ok.
 code_change(_FromVsn, S, _Extra) ->
     {ok, S}.
 
-stop_node() ->
-    StopDelay = setup:get_env(setup, stop_delay, 5000),
-    error_logger:info_msg("Setup stopping...(Delay=~p)~n", [StopDelay]),
-    timer:sleep(StopDelay),
-    rpc:eval_everywhere(init,stop,[0]).


### PR DESCRIPTION
Having start phase errors crash `setup_srv` causes very noisy node shutdown.
This change catches the error and performs a much cleaner shutdown.